### PR TITLE
fixing logout format

### DIFF
--- a/templates/pod_logs_output.html
+++ b/templates/pod_logs_output.html
@@ -23,7 +23,7 @@
         <br>
         <div class="px-6 py-4 m-4 max-w-full rounded overflow-hidden shadow-lg border border-green-300 bg-gray-100">
         <div class="font-serif text-gray-700 text-sm whitespace-pre-wrap">
-<pre><code class="language-bash font-serif text-gray-700 text-sm"> {{ logs }} </code></pre>
+<pre><code class="language-bash font-serif text-gray-700 text-sm">{{ logs }}</code></pre>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Before:

<img width="621" alt="Screen Shot 2019-07-17 at 12 14 38 PM" src="https://user-images.githubusercontent.com/538171/61404614-a940e100-a88c-11e9-8134-6b10a99df5c8.png">


After:

<img width="671" alt="Screen Shot 2019-07-17 at 12 14 46 PM" src="https://user-images.githubusercontent.com/538171/61404611-a6de8700-a88c-11e9-9c78-37507fe024a6.png">
