### PR TITLE
adding max-h-full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ This file is used to list changes made in each version of the Dinghy-ping
 
 ## unreleased
 
+## v0.3.1 (2019-07-26)
+- [Zane] - adding max-h-full to fix truncated logout in HTML
+
 ## v0.3.0 (2019-07-26)
 
--[Zane]
+- [Zane]
   * Tail lines feature, default 100. This changes behavior of log viewing
   * Add parameter option for preview line numbers
   * Update function docs

--- a/templates/pod_logs_output.html
+++ b/templates/pod_logs_output.html
@@ -21,7 +21,7 @@
   <div class="px-6 py-4">
     <h1 class="text-xl font-semibold hover:text-green-400"><a href="/" class="no-underline hover:underline">Dinghy Ping - Pod Logs</a></h1>
     <br>
-    <div class="px-6 py-4 m-4 max-w-full rounded overflow-hidden shadow-lg border border-green-300 bg-gray-100">
+    <div class="px-6 py-4 m-4 max-w-full max-h-full rounded overflow-hidden shadow-lg border border-green-300 bg-gray-100">
     <div class="font-serif text-gray-700 text-sm whitespace-pre-wrap">
 <pre><code class="language-bash font-serif text-gray-700 text-sm">{{ logs }}</code></pre>
     </div>


### PR DESCRIPTION
Allow box for log output to grow larger when long tail_lines length requested by user